### PR TITLE
Update Artisan publish command for Laravel 5

### DIFF
--- a/image/getting_started/installation.md
+++ b/image/getting_started/installation.md
@@ -96,7 +96,7 @@ By default Intervention Image uses PHP's GD library extension to process all ima
 
 #### Publish configuration in Laravel 5
 
-> $ php artisan vendor:publish
+> $ php artisan vendor:publish --provider="Intervention\Image\ImageServiceProviderLaravel5"
 
 
 #### Publish configuration in Laravel 4


### PR DESCRIPTION
By providing the provider to the command it will only publish the assets defined in that service provider. Without that option all assets from all providers will be published, which can be a pain. Also, the option provided must be the Laravel 5 specific service provider, Artisan doesn't seem to be able to determine the assets from the normal service provider.