### PR TITLE
Fix variable name in example code

### DIFF
--- a/image/api/encode.md
+++ b/image/api/encode.md
@@ -30,7 +30,7 @@ Instance of Intervention\Image\Image with attached encoded image data. Instance 
 
 ```php
 // encode png image as jpg
-$png = (string) Image::make('public/foo.png')->encode('jpg', 75);
+$jpg = (string) Image::make('public/foo.png')->encode('jpg', 75);
 
 // encode image as data-url
 $data = (string) Image::make('public/bar.png')->encode('data-url');


### PR DESCRIPTION
Since the PNG data is converted into JPEG, it make more sense to store the result in a `$jpg` variable rather than one called `$png`.

Moreover, this change brings consistency with the data-url example, which uses a `$data` variable to store its result.