### PR TITLE
Correct default background colors

### DIFF
--- a/image/api/resizeCanvas.md
+++ b/image/api/resizeCanvas.md
@@ -36,7 +36,7 @@ Determine that the resizing is going to happen in relative mode. Meaning that th
 
 
 ### bgcolor (optional)
-A background color for the new areas of the image. The background color can be passed in in different [color formats](/getting_started/formats). Default: ```#000000```
+A background color for the new areas of the image. The background color can be passed in different [color formats](/getting_started/formats). Default: ```#ffffff```
 
 
 ## Return Values

--- a/image/api/resizeCanvas.md
+++ b/image/api/resizeCanvas.md
@@ -36,7 +36,7 @@ Determine that the resizing is going to happen in relative mode. Meaning that th
 
 
 ### bgcolor (optional)
-A background color for the new areas of the image. The background color can be passed in different [color formats](/getting_started/formats). Default: ```#ffffff```
+A background color for the new areas of the image. The background color can be passed in different [color formats](/getting_started/formats). Default: ```#ffffff```, transparent if supported by the output format
 
 
 ## Return Values

--- a/image/api/rotate.md
+++ b/image/api/rotate.md
@@ -12,7 +12,7 @@ Rotate the current image counter-clockwise by a given **angle**. Optionally defi
 The rotation angle in degrees to rotate the image counter-clockwise.
 
 ### bgcolor (optional)
-A background color for the uncovered zone after the rotation. The background color can be passed in in different [color formats](/getting_started/formats). Default: ```#000000```
+A background color for the uncovered zone after the rotation. The background color can be passed in different [color formats](/getting_started/formats). Default: ```#ffffff```
 
 
 ## Return Values

--- a/image/api/rotate.md
+++ b/image/api/rotate.md
@@ -12,7 +12,7 @@ Rotate the current image counter-clockwise by a given **angle**. Optionally defi
 The rotation angle in degrees to rotate the image counter-clockwise.
 
 ### bgcolor (optional)
-A background color for the uncovered zone after the rotation. The background color can be passed in different [color formats](/getting_started/formats). Default: ```#ffffff```
+A background color for the uncovered zone after the rotation. The background color can be passed in different [color formats](/getting_started/formats). Default: ```#ffffff```, transparent if supported by the output format
 
 
 ## Return Values


### PR DESCRIPTION
Follow-up to https://github.com/Intervention/image/pull/717.

These `#ffffff` come from the null case in [AbstractColor](https://github.com/Intervention/image/blob/master/src/Intervention/Image/AbstractColor.php) `parse()`.