### PR TITLE
Add an extra example for resize()

### DIFF
--- a/image/api/resize.md
+++ b/image/api/resize.md
@@ -64,6 +64,13 @@ $img->resize(null, 400, function ($constraint) {
     $constraint->aspectRatio();
     $constraint->upsize();
 });
+
+// resize the image so that the largest side fits within the limit; the smaller
+// side will be scaled to maintain the original aspect ratio
+$img->resize(400, 400, function ($constraint) {
+    $constraint->aspectRatio();
+    $constraint->upsize();
+});
 ```
 
 ## See also


### PR DESCRIPTION
Scaling an image to fit within specific dimension, without cropping or changing proportions, is a common operation. It would be worth mentioning in the documentation.
