### PR TITLE
Update text-fonts.md page to v3 methods

### DIFF
--- a/image/v3/modifying/text-fonts.md
+++ b/image/v3/modifying/text-fonts.md
@@ -37,7 +37,7 @@ $image->text('The quick brown fox', 120, 100);
 
 To define the overall appearance of the text and set more details you can pass
 a callback as an optional parameter. The callback places the calls on the
-FontInterface and listen to the following methods.
+FontInterface and listens for following methods.
 
 #### Example
 

--- a/image/v3/modifying/text-fonts.md
+++ b/image/v3/modifying/text-fonts.md
@@ -18,7 +18,7 @@ a callback as the fourth parameter.
 | text | string | The text that will be written to the image. |
 | x | integer | Coordinate on x-axis defining the base point of the first character. |
 | y | integer | Coordinate on y-axis defining the base point of the first character. |
-| font | callable|FontInterface | Callback function to configure the font appearance or `Typography\Font` instance. |
+| font | callable or FontInterface | Callback function to configure the font appearance or `Typography\Font` instance. |
 
 
 #### Examples

--- a/image/v3/modifying/text-fonts.md
+++ b/image/v3/modifying/text-fonts.md
@@ -5,7 +5,7 @@
 
 ## Writing text
 
-> public Image::text(string $text, int $x, int $y, callable $settings): ImageInterface
+> public Image::text(string $text, int $x, int $y, callable|FontInterface $font): ImageInterface
 
 Write a **text** string at the basepoint position of **x, y** to the current
 image. You can define more details like font-size, font-file and alignment via
@@ -18,7 +18,7 @@ a callback as the fourth parameter.
 | text | string | The text that will be written to the image. |
 | x | integer | Coordinate on x-axis defining the base point of the first character. |
 | y | integer | Coordinate on y-axis defining the base point of the first character. |
-| settings | callable | Callback function to configure the font appearance. |
+| font | callable|FontInterface | Callback function to configure the font appearance or `Typography\Font` instance. |
 
 
 #### Examples
@@ -37,7 +37,7 @@ $image->text('The quick brown fox', 120, 100);
 
 To define the overall appearance of the text and set more details you can pass
 a callback as an optional parameter. The callback places the calls on the
-FontInterface and listens to the following methods.
+FontInterface and listen to the following methods.
 
 #### Example
 
@@ -49,21 +49,21 @@ $image = ImageManager::imagick()->read('images/example.jpg');
 
 // write text to image
 $image->text('The quick brown fox', 120, 100, function ($font) {
-    $font->filename('./fonts/comic-sans.ttf');
-    $font->color('#b01735');
-    $font->size(70);
-    $font->align('center');
-    $font->valign('middle');
-    $font->lineHeight(1.6);
-    $font->angle(10);
+    $font->setFilename('./fonts/comic-sans.ttf');
+    $font->setColor('#b01735');
+    $font->setSize(70);
+    $font->setAlignment('center');
+    $font->setValignment('middle');
+    $font->setLineHeight(1.6);
+    $font->setAngle(10);
 });
 ```
 
 ### Font size
 
-> public FontInterface::size(float $size): FontInterface
+> public FontInterface::setSize(float $size): FontInterface
 
-Define a font size. By default a value of `12` will be applied.
+Define a font size. By default, a value of `12` will be applied.
 
 #### Parameters
 
@@ -73,9 +73,9 @@ Define a font size. By default a value of `12` will be applied.
 
 ### Font file
 
-> public FontInterface::filename(string $filename): FontInterface
+> public FontInterface::setFilename(string $filename): FontInterface
 
-Set a path to a font file in file system in which the text should be written.
+Set a path to a font file in the file system for the text.
 
 #### Parameters
 
@@ -85,7 +85,7 @@ Set a path to a font file in file system in which the text should be written.
 
 ### Color
 
-> public FontInterface::color(mixed $color): FontInterface
+> public FontInterface::setColor(mixed $color): FontInterface
 
 Define the text color in one of the valid [color formats](/v3/introduction/formats#color-formats).
 
@@ -97,7 +97,7 @@ Define the text color in one of the valid [color formats](/v3/introduction/forma
 
 ### Horizontal alignment
 
-> public FontInterface::align(string $align): FontInterface
+> public FontInterface::setAlignment(string $align): FontInterface
 
 Define the horizontal alignment of the text to be written starting from the
 base point. Possible values are left, right and center. Default: `left`
@@ -110,7 +110,7 @@ base point. Possible values are left, right and center. Default: `left`
 
 ### Vertical alignment
 
-> public FontInterface::valign(string $valign): FontInterface
+> public FontInterface::setValignment(string $valign): FontInterface
 
 Define the vertical alignment of the text to be written starting from the base
 point. Possible values are top, bottom and middle. Default: `bottom`
@@ -123,7 +123,7 @@ point. Possible values are top, bottom and middle. Default: `bottom`
 
 ### Rotation
 
-> public FontInterface::angle(float $angle): FontInterface
+> public FontInterface::setAngle(float $angle): FontInterface
 
 Rotate the text block clockwise with a desired angle.
 
@@ -135,13 +135,13 @@ Rotate the text block clockwise with a desired angle.
 
 ### Line height
 
-> public FontInterface::lineHeight(float $height): FontInterface
+> public FontInterface::setLineHeight(float $height): FontInterface
 
-Define the line height of the text block. Applies only for multi line text.
+Define the line height of the text block. Applies only to multi-line text.
 Default value is `1.25`.
 
 #### Parameters
 
 | Name | Type | Description |
 | - | - | - |
-| height | float | Line height for multi line text block |
+| height | float | Line height for multi-line text block |

--- a/image/v3/modifying/text-fonts.md
+++ b/image/v3/modifying/text-fonts.md
@@ -43,25 +43,26 @@ FontInterface and listens for following methods.
 
 ```php
 use Intervention\Image\ImageManager;
+use Intervention\Image\Typography\FontFactory;
 
 // create test image
 $image = ImageManager::imagick()->read('images/example.jpg');
 
 // write text to image
-$image->text('The quick brown fox', 120, 100, function ($font) {
-    $font->setFilename('./fonts/comic-sans.ttf');
-    $font->setColor('#b01735');
-    $font->setSize(70);
-    $font->setAlignment('center');
-    $font->setValignment('middle');
-    $font->setLineHeight(1.6);
-    $font->setAngle(10);
+$image->text('The quick brown fox', 120, 100, function (FontFactory $font) {
+    $font->filename('./fonts/comic-sans.ttf');
+    $font->color('#b01735');
+    $font->size(70);
+    $font->align('center');
+    $font->valign('middle');
+    $font->lineHeight(1.6);
+    $font->angle(10);
 });
 ```
 
 ### Font size
 
-> public FontInterface::setSize(float $size): FontInterface
+> public FontInterface::size(float $size): FontInterface
 
 Define a font size. By default, a value of `12` will be applied.
 
@@ -73,7 +74,7 @@ Define a font size. By default, a value of `12` will be applied.
 
 ### Font file
 
-> public FontInterface::setFilename(string $filename): FontInterface
+> public FontInterface::filename(string $filename): FontInterface
 
 Set a path to a font file in the file system for the text.
 
@@ -85,7 +86,7 @@ Set a path to a font file in the file system for the text.
 
 ### Color
 
-> public FontInterface::setColor(mixed $color): FontInterface
+> public FontInterface::color(mixed $color): FontInterface
 
 Define the text color in one of the valid [color formats](/v3/introduction/formats#color-formats).
 
@@ -97,7 +98,7 @@ Define the text color in one of the valid [color formats](/v3/introduction/forma
 
 ### Horizontal alignment
 
-> public FontInterface::setAlignment(string $align): FontInterface
+> public FontInterface::align(string $align): FontInterface
 
 Define the horizontal alignment of the text to be written starting from the
 base point. Possible values are left, right and center. Default: `left`
@@ -110,7 +111,7 @@ base point. Possible values are left, right and center. Default: `left`
 
 ### Vertical alignment
 
-> public FontInterface::setValignment(string $valign): FontInterface
+> public FontInterface::valign(string $valign): FontInterface
 
 Define the vertical alignment of the text to be written starting from the base
 point. Possible values are top, bottom and middle. Default: `bottom`
@@ -123,7 +124,7 @@ point. Possible values are top, bottom and middle. Default: `bottom`
 
 ### Rotation
 
-> public FontInterface::setAngle(float $angle): FontInterface
+> public FontInterface::angle(float $angle): FontInterface
 
 Rotate the text block clockwise with a desired angle.
 
@@ -135,7 +136,7 @@ Rotate the text block clockwise with a desired angle.
 
 ### Line height
 
-> public FontInterface::setLineHeight(float $height): FontInterface
+> public FontInterface::lineHeight(float $height): FontInterface
 
 Define the line height of the text block. Applies only to multi-line text.
 Default value is `1.25`.


### PR DESCRIPTION
This PR fixes the font methods in the documentation. It seems it's currently showing the v2 one.

- Updates methods to `set...`.
- Updates `align` and `valign` to `setAlignment` and `setValignment`.