### PR TITLE
Fix the documentation on Modifying(resize) the images

### DIFF
--- a/image/v3/modifying/resizing.md
+++ b/image/v3/modifying/resizing.md
@@ -112,8 +112,8 @@ $image->scale(200, 100); // 200 x 150
 
 > public Image::scaleDown(?int $width, ?int $height): ImageInterface
 
-The method `resize()` simply stretches the image to the desired size. Use
-`resizeDown()` to change the size but do not exceed the original size of the
+The method `scale()` resize the image and maintain the aspect ratio. While
+`scaleDown()` is similar to `scale()` only difference is it does't exceed the original size of the
 image. The method support [named arguments](https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments)
 to target just one axis for the modification. 
 


### PR DESCRIPTION
1. Fix the documentation and added the appropriate method names in documentation section of https://image.intervention.io/v3/modifying/resizing#scaling-images  